### PR TITLE
Cf 19 Remove settings from context

### DIFF
--- a/annot8-common/annot8-common-implementations/src/main/java/io/annot8/common/implementations/configuration/ComponentConfigurer.java
+++ b/annot8-common/annot8-common-implementations/src/main/java/io/annot8/common/implementations/configuration/ComponentConfigurer.java
@@ -5,7 +5,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,6 +15,8 @@ import io.annot8.core.components.Annot8Component;
 import io.annot8.core.components.Resource;
 import io.annot8.core.context.Context;
 import io.annot8.core.settings.Settings;
+
+import static java.util.stream.Collectors.toList;
 
 public class ComponentConfigurer {
 
@@ -36,10 +37,10 @@ public class ComponentConfigurer {
 
   public Map<String, Resource> configureResources(ResourcesHolder resourcesHolder) {
     resourcesHolder
-        .getResourcesToConfiguration()
+        .getResources()
         .forEach(
-            (resource, settings) -> {
-              if (configureComponent(resource, settings)) {
+            (resource) -> {
+              if (configureComponent(resource)) {
                 String id = resourcesHolder.getId(resource);
                 resources.put(id, resource);
               }
@@ -53,24 +54,13 @@ public class ComponentConfigurer {
   }
 
   public <T extends Annot8Component> List<T> configureComponents(ComponentHolder<T> holder) {
-    return configureAllComponents(holder.getComponentToConfiguration());
+    return holder.getComponents()
+            .stream()
+            .filter(this::configureComponent)
+            .collect(toList());
   }
 
-  protected <T extends Annot8Component> List<T> configureAllComponents(
-      Map<T, Collection<Settings>> componentToConfiguration) {
-
-    return componentToConfiguration
-        .entrySet()
-        .stream()
-        .filter(e -> configureComponent(e.getKey(), e.getValue()))
-        .map(Map.Entry::getKey)
-        .collect(Collectors.toList());
-  }
-
-  // TODO: This will change since settings are no longer passed like this
-  public <T extends Annot8Component> boolean configureComponent(
-      T component, Collection<Settings> settings) {
-
+  public <T extends Annot8Component> boolean configureComponent(T component) {
     // TODO: COmpletely ignore capabilties here.. we could check for resources etc
 
     try {

--- a/annot8-common/annot8-common-implementations/src/main/java/io/annot8/common/implementations/configuration/ComponentConfigurer.java
+++ b/annot8-common/annot8-common-implementations/src/main/java/io/annot8/common/implementations/configuration/ComponentConfigurer.java
@@ -67,13 +67,14 @@ public class ComponentConfigurer {
         .collect(Collectors.toList());
   }
 
+  // TODO: This will change since settings are no longer passed like this
   public <T extends Annot8Component> boolean configureComponent(
       T component, Collection<Settings> settings) {
 
     // TODO: COmpletely ignore capabilties here.. we could check for resources etc
 
     try {
-      final SimpleContext componentContext = new SimpleContext(settings, resources);
+      final SimpleContext componentContext = new SimpleContext(resources);
       Context context = new MergedContext(globalContext, componentContext);
       component.configure(context);
       return true;

--- a/annot8-common/annot8-common-implementations/src/main/java/io/annot8/common/implementations/configuration/ComponentHolder.java
+++ b/annot8-common/annot8-common-implementations/src/main/java/io/annot8/common/implementations/configuration/ComponentHolder.java
@@ -1,9 +1,7 @@
 /* Annot8 (annot8.io) - Licensed under Apache-2.0. */
 package io.annot8.common.implementations.configuration;
 
-import java.util.Collection;
-import java.util.LinkedHashMap;
-import java.util.Map;
+import java.util.*;
 
 import io.annot8.common.utils.java.CollectionUtils;
 import io.annot8.core.components.Annot8Component;
@@ -11,14 +9,14 @@ import io.annot8.core.settings.Settings;
 
 public class ComponentHolder<T extends Annot8Component> {
 
-  private final Map<T, Collection<Settings>> componentToConfiguration = new LinkedHashMap<>();
+  private final List<T> components = new LinkedList<>();
 
-  public ComponentHolder add(final T t, final Collection<Settings> configuration) {
-    componentToConfiguration.put(t, CollectionUtils.nonNullCollection(configuration));
+  public ComponentHolder add(final T t) {
+    components.add(t);
     return this;
   }
 
-  public Map<T, Collection<Settings>> getComponentToConfiguration() {
-    return componentToConfiguration;
+  public List<T> getComponents() {
+    return Collections.unmodifiableList(components);
   }
 }

--- a/annot8-common/annot8-common-implementations/src/main/java/io/annot8/common/implementations/configuration/ResourcesHolder.java
+++ b/annot8-common/annot8-common-implementations/src/main/java/io/annot8/common/implementations/configuration/ResourcesHolder.java
@@ -1,10 +1,7 @@
 /* Annot8 (annot8.io) - Licensed under Apache-2.0. */
 package io.annot8.common.implementations.configuration;
 
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.Map;
+import java.util.*;
 
 import io.annot8.common.utils.java.CollectionUtils;
 import io.annot8.core.components.Resource;
@@ -12,19 +9,16 @@ import io.annot8.core.settings.Settings;
 
 public class ResourcesHolder {
 
-  private final Map<Resource, Collection<Settings>> resourcesToConfiguration =
-      new LinkedHashMap<>();
   private final Map<Resource, String> resourcesToId = new HashMap<>();
 
   public ResourcesHolder addResource(
-      final String id, final Resource resource, final Collection<Settings> configuration) {
-    resourcesToConfiguration.put(resource, CollectionUtils.nonNullCollection(configuration));
+      final String id, final Resource resource) {
     resourcesToId.put(resource, id);
     return this;
   }
 
-  public Map<Resource, Collection<Settings>> getResourcesToConfiguration() {
-    return resourcesToConfiguration;
+  public Set<Resource> getResources() {
+    return Collections.unmodifiableSet(resourcesToId.keySet());
   }
 
   public Map<Resource, String> getResourcesToId() {

--- a/annot8-common/annot8-common-implementations/src/main/java/io/annot8/common/implementations/context/MergedContext.java
+++ b/annot8-common/annot8-common-implementations/src/main/java/io/annot8/common/implementations/context/MergedContext.java
@@ -19,21 +19,6 @@ public class MergedContext implements Context {
   }
 
   @Override
-  public Stream<Settings> getSettings() {
-    return contexts.stream().flatMap(Context::getSettings);
-  }
-
-  @Override
-  public <T extends Settings> Optional<T> getSettings(Class<T> clazz) {
-    return contexts
-        .stream()
-        .map(c -> c.getSettings(clazz))
-        .filter(Optional::isPresent)
-        .map(Optional::get)
-        .findFirst();
-  }
-
-  @Override
   public <T extends Resource> Optional<T> getResource(String key, Class<T> clazz) {
     return contexts
         .stream()

--- a/annot8-common/annot8-common-implementations/src/main/java/io/annot8/common/implementations/context/SimpleContext.java
+++ b/annot8-common/annot8-common-implementations/src/main/java/io/annot8/common/implementations/context/SimpleContext.java
@@ -16,26 +16,14 @@ import io.annot8.core.settings.Settings;
 public class SimpleContext implements Context {
 
   private final Map<String, Resource> resources = new HashMap<>();
-  private final Collection<Settings> settings;
 
-  /** Create a new instance, with no settings and no resources */
+  /** Create a new instance, with no resources */
   public SimpleContext() {
-    this(null, null);
+    this(null);
   }
 
-  /** Create a new instance, with the specified settings and no resources */
-  public SimpleContext(Collection<Settings> settings) {
-    this(settings, null);
-  }
-
-  /** Create a new instance, with no settings and the specified resources */
+  /** Create a new instance, with the resources */
   public SimpleContext(Map<String, Resource> resources) {
-    this(null, resources);
-  }
-
-  /** Create a new instance, with the specified settings and resources */
-  public SimpleContext(Collection<Settings> settings, Map<String, Resource> resources) {
-    this.settings = settings;
     if (resources != null) {
       this.resources.putAll(resources);
     }
@@ -44,11 +32,6 @@ public class SimpleContext implements Context {
   /** Add a new resource to the context object */
   public void addResource(String key, Resource resource) {
     resources.put(key, resource);
-  }
-
-  @Override
-  public Stream<Settings> getSettings() {
-    return settings != null ? settings.stream() : Stream.empty();
   }
 
   @Override
@@ -78,12 +61,12 @@ public class SimpleContext implements Context {
 
   @Override
   public String toString() {
-    return this.getClass().getName() + " [settings=" + settings + ", resources=" + resources + "]";
+    return this.getClass().getName() + " [resources=" + resources + "]";
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(settings, resources);
+    return Objects.hash( resources);
   }
 
   @Override
@@ -102,7 +85,6 @@ public class SimpleContext implements Context {
               r.ifPresent(resource -> resourceMap.put(s, resource));
             });
 
-    return Objects.equals(c.getSettings(), getSettings())
-        && Objects.equals(resourceMap, this.resources);
+    return Objects.equals(resourceMap, this.resources);
   }
 }

--- a/annot8-common/annot8-common-implementations/src/main/java/io/annot8/common/implementations/delegates/DelegateContext.java
+++ b/annot8-common/annot8-common-implementations/src/main/java/io/annot8/common/implementations/delegates/DelegateContext.java
@@ -13,18 +13,7 @@ public class DelegateContext implements Context {
   private final Context delegate;
 
   public DelegateContext(Context delegate) {
-
     this.delegate = delegate;
-  }
-
-  @Override
-  public Stream<Settings> getSettings() {
-    return delegate.getSettings();
-  }
-
-  @Override
-  public <T extends Settings> Optional<T> getSettings(Class<T> clazz) {
-    return delegate.getSettings(clazz);
   }
 
   @Override

--- a/annot8-common/annot8-common-implementations/src/test/java/io/annot8/common/implementations/configuration/ComponentConfigurerTest.java
+++ b/annot8-common/annot8-common-implementations/src/test/java/io/annot8/common/implementations/configuration/ComponentConfigurerTest.java
@@ -65,8 +65,7 @@ class ComponentConfigurerTest {
     ResourcesHolder holder = new ResourcesHolder();
 
     Resource r = mock(Resource.class);
-    Collection<Settings> settings = new ArrayList<>();
-    holder.addResource("local", r, settings);
+    holder.addResource("local", r);
 
     final Map<String, Resource> resources = configurer.configureResources(holder);
     final Map<String, Resource> gotResources = configurer.getResources();
@@ -88,12 +87,10 @@ class ComponentConfigurerTest {
     ComponentHolder<Processor> holder = new ComponentHolder<>();
 
     Processor p = mock(Processor.class);
-    Collection<Settings> settings = new ArrayList<>();
-    holder.add(p, settings);
+    holder.add(p);
 
     Processor q = mock(Processor.class);
-    Collection<Settings> qSettings = new ArrayList<>();
-    holder.add(q, qSettings);
+    holder.add(q);
 
     final List<Processor> processors = configurer.configureComponents(holder);
 
@@ -104,9 +101,8 @@ class ComponentConfigurerTest {
   @Test
   void configureComponent() throws BadConfigurationException, MissingResourceException {
     Processor p = mock(Processor.class);
-    Collection<Settings> settings = new ArrayList<>();
 
-    configurer.configureComponent(p, settings);
+    configurer.configureComponent(p);
 
     verify(p).configure(any(Context.class));
   }

--- a/annot8-common/annot8-common-implementations/src/test/java/io/annot8/common/implementations/configuration/ComponentHolderTest.java
+++ b/annot8-common/annot8-common-implementations/src/test/java/io/annot8/common/implementations/configuration/ComponentHolderTest.java
@@ -30,35 +30,20 @@ class ComponentHolderTest {
   @Test
   public void add() {
 
-    fixtures().forEach(t -> addProcessor(t.getA(), t.getB()));
+    fixtures().forEach(this::addProcessor);
 
-    assertThat(holder.getComponentToConfiguration()).hasSize(3);
+    assertThat(holder.getComponents()).hasSize(3);
   }
 
-  void addProcessor(Processor r, Collection<Settings> settings) {
-
-    holder.add(r, settings);
-
-    Collection<Settings> expectedSettings = settings == null ? Collections.emptyList() : settings;
-    assertThat(holder.getComponentToConfiguration().get(r))
-        .containsExactlyElementsOf(expectedSettings);
+  void addProcessor(Processor r) {
+    holder.add(r);
   }
 
-  static Stream<Tuple2<Processor, Collection<Settings>>> fixtures() {
+  static Stream<Processor> fixtures() {
     return Stream.of(
-        new Tuple2<>(new FakeProcessor(), null),
-        new Tuple2<>(new FakeProcessor(), Collections.emptyList()),
-        new Tuple2<>(
-            new FakeProcessor(),
-            Arrays.asList(new ResourcesHolderTest.FakeSettings(), new FakeSettings())));
-  }
-
-  public static class FakeSettings implements Settings {
-
-    @Override
-    public boolean validate() {
-      return true;
-    }
+        new FakeProcessor(),
+        new FakeProcessor(),
+            new FakeProcessor());
   }
 
   public static class FakeProcessor implements Processor {

--- a/annot8-common/annot8-common-implementations/src/test/java/io/annot8/common/implementations/configuration/ResourcesHolderTest.java
+++ b/annot8-common/annot8-common-implementations/src/test/java/io/annot8/common/implementations/configuration/ResourcesHolderTest.java
@@ -8,6 +8,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.stream.Stream;
 
+import io.annot8.common.data.tuple.Tuple2;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -27,39 +28,28 @@ class ResourcesHolderTest {
   @Test
   public void addResources() {
 
-    resourceFixtures().forEach(t -> addResource(t.getA(), t.getB(), t.getC()));
+    resourceFixtures().forEach(t -> addResource(t.getA(), t.getB()));
 
     assertThat(holder.getResources()).hasSize(3);
     assertThat(holder.getResourcesToId()).hasSize(3);
   }
 
-  void addResource(String id, Resource r, Collection<Settings> settings) {
+  void addResource(String id, Resource r) {
 
-    holder.addResource(id, r, settings);
+    holder.addResource(id, r);
 
     assertThat(holder.getId(r)).isEqualTo(id);
 
     assertThat(holder.getResourcesToId()).containsEntry(r, id);
 
-    Collection<Settings> expectedSettings = settings == null ? Collections.emptyList() : settings;
-    assertThat(holder.getResources().get(r))
-        .containsExactlyElementsOf(expectedSettings);
   }
 
-  static Stream<Tuple3<String, Resource, Collection<Settings>>> resourceFixtures() {
+  static Stream<Tuple2<String, Resource>> resourceFixtures() {
     return Stream.of(
-        new Tuple3<>("id1", new FakeResource(), null),
-        new Tuple3<>("id2", new FakeResource(), Collections.emptyList()),
-        new Tuple3<>(
-            "id3", new FakeResource(), Arrays.asList(new FakeSettings(), new FakeSettings())));
-  }
-
-  public static class FakeSettings implements Settings {
-
-    @Override
-    public boolean validate() {
-      return true;
-    }
+        new Tuple2<>("id1", new FakeResource()),
+        new Tuple2<>("id2", new FakeResource()),
+        new Tuple2<>(
+            "id3", new FakeResource()));
   }
 
   public static class FakeResource implements Resource {}

--- a/annot8-common/annot8-common-implementations/src/test/java/io/annot8/common/implementations/configuration/ResourcesHolderTest.java
+++ b/annot8-common/annot8-common-implementations/src/test/java/io/annot8/common/implementations/configuration/ResourcesHolderTest.java
@@ -2,7 +2,6 @@
 package io.annot8.common.implementations.configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -30,7 +29,7 @@ class ResourcesHolderTest {
 
     resourceFixtures().forEach(t -> addResource(t.getA(), t.getB(), t.getC()));
 
-    assertThat(holder.getResourcesToConfiguration()).hasSize(3);
+    assertThat(holder.getResources()).hasSize(3);
     assertThat(holder.getResourcesToId()).hasSize(3);
   }
 
@@ -43,7 +42,7 @@ class ResourcesHolderTest {
     assertThat(holder.getResourcesToId()).containsEntry(r, id);
 
     Collection<Settings> expectedSettings = settings == null ? Collections.emptyList() : settings;
-    assertThat(holder.getResourcesToConfiguration().get(r))
+    assertThat(holder.getResources().get(r))
         .containsExactlyElementsOf(expectedSettings);
   }
 

--- a/annot8-common/annot8-common-implementations/src/test/java/io/annot8/common/implementations/context/MergedContextTest.java
+++ b/annot8-common/annot8-common-implementations/src/test/java/io/annot8/common/implementations/context/MergedContextTest.java
@@ -22,29 +22,15 @@ class MergedContextTest {
 
   @Mock Resource bResource;
 
-  @Mock Settings aSettings;
-
-  @Mock Settings bSettings;
-
   private SimpleContext a;
   private SimpleContext b;
   private MergedContext m;
 
   @BeforeEach
   public void beforeEach() {
-    a = new SimpleContext(Arrays.asList(aSettings), Map.of("a", aResource));
-    b = new SimpleContext(Arrays.asList(bSettings), Map.of("b", bResource));
+    a = new SimpleContext(Map.of("a", aResource));
+    b = new SimpleContext(Map.of("b", bResource));
     m = new MergedContext(a, b);
-  }
-
-  @Test
-  void getSettings() {
-    assertThat(m.getSettings()).containsExactly(aSettings, bSettings);
-  }
-
-  @Test
-  void getSettings1() {
-    assertThat(m.getSettings(Settings.class).get()).isEqualTo(aSettings);
   }
 
   @Test

--- a/annot8-common/annot8-common-implementations/src/test/java/io/annot8/common/implementations/context/SimpleContextTest.java
+++ b/annot8-common/annot8-common-implementations/src/test/java/io/annot8/common/implementations/context/SimpleContextTest.java
@@ -29,8 +29,6 @@ public class SimpleContextTest {
     context.addResource("resource1", r1);
     context.addResource("resource2", r2);
 
-    Assertions.assertEquals(0, context.getSettings().count());
-
     Assertions.assertFalse(context.getResource("foo", Resource.class).isPresent());
     Assertions.assertFalse(context.getResource("resource1", TestResource.class).isPresent());
     Assertions.assertTrue(context.getResource("resource1", Resource.class).isPresent());
@@ -58,8 +56,6 @@ public class SimpleContextTest {
 
     SimpleContext context = new SimpleContext(r);
 
-    Assertions.assertEquals(0, context.getSettings().count());
-
     Assertions.assertFalse(context.getResource("foo", Resource.class).isPresent());
     Assertions.assertFalse(context.getResource("resource1", NotTestResource.class).isPresent());
     Assertions.assertTrue(context.getResource("resource2", Resource.class).isPresent());
@@ -81,10 +77,7 @@ public class SimpleContextTest {
     Settings s = mock(Settings.class);
     BaseItemFactory itemFactory = mock(BaseItemFactory.class);
 
-    SimpleContext context = new SimpleContext(Collections.singletonList(s));
-
-    Assertions.assertEquals(1, context.getSettings().count());
-    Assertions.assertEquals(s, context.getSettings().findFirst().get());
+    SimpleContext context = new SimpleContext();
 
     List<String> keys = context.getResourceKeys().collect(Collectors.toList());
     Assertions.assertTrue(keys.isEmpty());
@@ -105,10 +98,7 @@ public class SimpleContextTest {
 
     BaseItemFactory itemFactory = mock(BaseItemFactory.class);
 
-    SimpleContext context = new SimpleContext(Collections.singletonList(s), r);
-
-    Assertions.assertEquals(1, context.getSettings().count());
-    Assertions.assertEquals(s, context.getSettings().findFirst().get());
+    SimpleContext context = new SimpleContext(r);
 
     Assertions.assertFalse(context.getResource("foo", Resource.class).isPresent());
     Assertions.assertFalse(context.getResource("resource1", TestResource.class).isPresent());

--- a/annot8-common/annot8-common-implementations/src/test/java/io/annot8/common/implementations/delegates/DelegateContextTest.java
+++ b/annot8-common/annot8-common-implementations/src/test/java/io/annot8/common/implementations/delegates/DelegateContextTest.java
@@ -29,17 +29,6 @@ class DelegateContextTest {
     context = new DelegateContext(delegate);
   }
 
-  @Test
-  void getSettings() {
-    final Stream<Settings> settings = context.getSettings();
-    Mockito.verify(delegate, Mockito.times(1)).getSettings();
-  }
-
-  @Test
-  void getSettings1() {
-    final Optional<Settings> result = context.getSettings(Settings.class);
-    Mockito.verify(delegate, Mockito.times(1)).getSettings(Settings.class);
-  }
 
   @Test
   void getResource() {

--- a/annot8-common/annot8-common-pipelines/src/main/java/io/annot8/common/pipelines/base/AbstractPipeBuilder.java
+++ b/annot8-common/annot8-common-pipelines/src/main/java/io/annot8/common/pipelines/base/AbstractPipeBuilder.java
@@ -21,15 +21,17 @@ public abstract class AbstractPipeBuilder implements PipeBuilder {
   private final ResourcesHolder resourcesHolder = new ResourcesHolder();
   private String name = "anonymous";
 
+  @Override
   public PipeBuilder addResource(
-      final String id, final Resource resource, final Collection<Settings> configuration) {
-    resourcesHolder.addResource(id, resource, configuration);
+      final String id, final Resource resource) {
+    resourcesHolder.addResource(id, resource);
     return this;
   }
 
+  @Override
   public PipeBuilder addProcessor(
-      final Processor processor, final Collection<Settings> configuration) {
-    processorHolder.add(processor, configuration);
+      final Processor processor) {
+    processorHolder.add(processor);
     return this;
   }
 

--- a/annot8-common/annot8-common-pipelines/src/main/java/io/annot8/common/pipelines/base/AbstractPipelineBuilder.java
+++ b/annot8-common/annot8-common-pipelines/src/main/java/io/annot8/common/pipelines/base/AbstractPipelineBuilder.java
@@ -52,14 +52,14 @@ public abstract class AbstractPipelineBuilder implements PipelineBuilder {
 
   @Override
   public PipelineBuilder addResource(
-      final String id, final Resource resource, final Collection<Settings> configuration) {
-    resourcesHolder.addResource(id, resource, configuration);
+      final String id, final Resource resource) {
+    resourcesHolder.addResource(id, resource);
     return this;
   }
 
   @Override
-  public PipelineBuilder addSource(final Source source, final Collection<Settings> configuration) {
-    sourceHolder.add(source, configuration);
+  public PipelineBuilder addSource(final Source source) {
+    sourceHolder.add(source);
     return this;
   }
 

--- a/annot8-common/annot8-common-pipelines/src/main/java/io/annot8/common/pipelines/elements/PipeBuilder.java
+++ b/annot8-common/annot8-common-pipelines/src/main/java/io/annot8/common/pipelines/elements/PipeBuilder.java
@@ -13,19 +13,10 @@ public interface PipeBuilder {
 
   PipeBuilder withName(String name);
 
-  default PipeBuilder addResource(
-      final String id, final Resource resource, final Settings... settings) {
-    return addResource(id, resource, Arrays.asList(settings));
-  }
+  PipeBuilder addResource(final String id, final Resource resource);
 
-  default PipeBuilder addProcessor(final Processor processor, final Settings... settings) {
-    return addProcessor(processor, Arrays.asList(settings));
-  }
+  PipeBuilder addProcessor(final Processor processor);
 
-  PipeBuilder addResource(
-      final String id, final Resource resource, final Collection<Settings> settings);
-
-  PipeBuilder addProcessor(final Processor processor, final Collection<Settings> settings);
 
   Pipe build() throws IncompleteException;
 }

--- a/annot8-common/annot8-common-pipelines/src/main/java/io/annot8/common/pipelines/elements/PipelineBuilder.java
+++ b/annot8-common/annot8-common-pipelines/src/main/java/io/annot8/common/pipelines/elements/PipelineBuilder.java
@@ -21,20 +21,10 @@ public interface PipelineBuilder {
 
   PipelineBuilder withName(String name);
 
-  default PipelineBuilder addResource(
-      final String id, final Resource resource, final Settings... settings) {
-    return addResource(id, resource, Arrays.asList(settings));
-  }
-
   PipelineBuilder addResource(
-      final String id, final Resource resource, final Collection<Settings> settings);
+      final String id, final Resource resource);
 
-  default PipelineBuilder addSource(final Source source, final Settings... settings) {
-    addSource(source, Arrays.asList(settings));
-    return this;
-  }
-
-  PipelineBuilder addSource(final Source source, final Collection<Settings> settings);
+  PipelineBuilder addSource(final Source source);
 
   default PipelineBuilder addPipe(final PipeBuilder pipe) throws IncompleteException {
     addPipe(DEFAULT_PIPE, pipe);

--- a/annot8-common/annot8-common-pipelines/src/main/java/io/annot8/common/pipelines/factory/configuration/ComponentConfiguration.java
+++ b/annot8-common/annot8-common-pipelines/src/main/java/io/annot8/common/pipelines/factory/configuration/ComponentConfiguration.java
@@ -11,5 +11,5 @@ public interface ComponentConfiguration {
 
   String getComponent();
 
-  Set<Settings> getSettings();
+  Settings getSettings();
 }

--- a/annot8-common/annot8-common-pipelines/src/main/java/io/annot8/common/pipelines/factory/configuration/SimpleComponentConfiguration.java
+++ b/annot8-common/annot8-common-pipelines/src/main/java/io/annot8/common/pipelines/factory/configuration/SimpleComponentConfiguration.java
@@ -1,9 +1,7 @@
 /* Annot8 (annot8.io) - Licensed under Apache-2.0. */
 package io.annot8.common.pipelines.factory.configuration;
 
-import java.util.Collection;
 import java.util.HashSet;
-import java.util.Set;
 
 import io.annot8.core.settings.Settings;
 
@@ -11,21 +9,21 @@ public class SimpleComponentConfiguration implements ComponentConfiguration {
 
   private String name;
   private String component;
-  private Set<Settings> settings = new HashSet<>();
+  private Settings settings;
 
   public SimpleComponentConfiguration() {
     // Do nothing
   }
 
-  public SimpleComponentConfiguration(String component, Collection<Settings> settings) {
+  public SimpleComponentConfiguration(String component, Settings settings) {
     this(null, component, settings);
   }
 
   public SimpleComponentConfiguration(
-      String name, String component, Collection<Settings> settings) {
+      String name, String component, Settings settings) {
     this.name = name;
     this.component = component;
-    this.settings.addAll(settings);
+    this.settings = settings;
   }
 
   @Override
@@ -47,11 +45,11 @@ public class SimpleComponentConfiguration implements ComponentConfiguration {
   }
 
   @Override
-  public Set<Settings> getSettings() {
+  public Settings getSettings() {
     return settings;
   }
 
-  public void setSettings(Set<Settings> settings) {
+  public void setSettings(Settings settings) {
     this.settings = settings;
   }
 }

--- a/annot8-common/annot8-common-pipelines/src/main/java/io/annot8/common/pipelines/factory/configuration/TypedComponentConfiguration.java
+++ b/annot8-common/annot8-common-pipelines/src/main/java/io/annot8/common/pipelines/factory/configuration/TypedComponentConfiguration.java
@@ -9,15 +9,15 @@ import io.annot8.core.settings.Settings;
 public class TypedComponentConfiguration<T extends Annot8Component> {
 
   private final Class<? extends T> componentClass;
-  private final Collection<Settings> settings;
+  private final Settings settings;
 
   public TypedComponentConfiguration(
-      Class<? extends T> componentClass, Collection<Settings> settings) {
+      Class<? extends T> componentClass, Settings settings) {
     this.componentClass = componentClass;
     this.settings = settings;
   }
 
-  public Collection<Settings> getSettings() {
+  public Settings getSettings() {
     return settings;
   }
 

--- a/annot8-common/annot8-common-pipelines/src/main/java/io/annot8/common/pipelines/simple/SimplePipeline.java
+++ b/annot8-common/annot8-common-pipelines/src/main/java/io/annot8/common/pipelines/simple/SimplePipeline.java
@@ -76,7 +76,7 @@ public class SimplePipeline extends AbstractTask implements Pipeline {
             definition.getPipes(), definition.getBranches(), definition.getMerges());
 
     plumber.plumb(AbstractPipelineBuilder.DEFAULT_PIPE);
-    componentConfigurer.configureComponent(plumber, Collections.emptyList());
+    componentConfigurer.configureComponent(plumber);
     pipe = plumber.getPipe();
   }
 

--- a/annot8-core/src/main/java/io/annot8/core/components/Annot8Component.java
+++ b/annot8-core/src/main/java/io/annot8/core/components/Annot8Component.java
@@ -5,9 +5,13 @@ import io.annot8.core.capabilities.Capabilities;
 import io.annot8.core.context.Context;
 import io.annot8.core.exceptions.BadConfigurationException;
 import io.annot8.core.exceptions.MissingResourceException;
+import io.annot8.core.settings.Settings;
 
-/** Base interface from which all other Annot8 components extend. */
-public interface Annot8Component extends AutoCloseable {
+/** Base interface from which all other Annot8 components extend.
+ *
+ * @param <S> settings class
+ */
+public interface Annot8Component<S extends Settings> extends AutoCloseable {
 
   /**
    * Configure this component using information from the given context.

--- a/annot8-core/src/main/java/io/annot8/core/components/Processor.java
+++ b/annot8-core/src/main/java/io/annot8/core/components/Processor.java
@@ -2,10 +2,13 @@
 package io.annot8.core.components;
 
 import io.annot8.core.helpers.WithProcessItem;
+import io.annot8.core.settings.Settings;
 
 /**
  * Base processor interface from which all processors extend.
  *
  * <p>Processors do work on an item, such as adding new annotations, or creating new content.
+ *
+ * @param <S> settings class
  */
-public interface Processor extends Annot8Component, WithProcessItem {}
+public interface Processor<S extends Settings> extends Annot8Component<S>, WithProcessItem {}

--- a/annot8-core/src/main/java/io/annot8/core/components/Resource.java
+++ b/annot8-core/src/main/java/io/annot8/core/components/Resource.java
@@ -1,8 +1,12 @@
 /* Annot8 (annot8.io) - Licensed under Apache-2.0. */
 package io.annot8.core.components;
 
+import io.annot8.core.settings.Settings;
+
 /**
  * A reusable resource (for example a database connection, or a preloaded dataset) that can be used
  * by other components.
+ *
+ * @param <S> settings class
  */
-public interface Resource extends Annot8Component {}
+public interface Resource<S extends Settings> extends Annot8Component<S> {}

--- a/annot8-core/src/main/java/io/annot8/core/components/Source.java
+++ b/annot8-core/src/main/java/io/annot8/core/components/Source.java
@@ -3,14 +3,17 @@ package io.annot8.core.components;
 
 import io.annot8.core.components.responses.SourceResponse;
 import io.annot8.core.data.ItemFactory;
+import io.annot8.core.settings.Settings;
 
 /**
  * Base processor interface from which all sources extend.
  *
  * <p>Sources read data from somewhere (e.g. a file system, or a database) and produce items that
  * will be processed by other components.
+ *
+ * @param <S> settings class
  */
-public interface Source extends Annot8Component {
+public interface Source<S extends Settings> extends Annot8Component<S> {
 
   /** Read from the data source and return new items if found */
   SourceResponse read(ItemFactory itemFactory);

--- a/annot8-core/src/main/java/io/annot8/core/context/Context.java
+++ b/annot8-core/src/main/java/io/annot8/core/context/Context.java
@@ -10,42 +10,6 @@ import io.annot8.core.settings.Settings;
 /** Base context interface from which all context implementations extend. */
 public interface Context {
 
-  /** The settings for the component that this context is being passed to. */
-  Stream<Settings> getSettings();
-
-  /** Return a settings object as the given class. */
-  default <T extends Settings> Optional<T> getSettings(final Class<T> clazz) {
-    final Stream<Settings> stream = getSettings();
-
-    return stream.filter(clazz::isInstance).map(clazz::cast).findFirst();
-  }
-
-  /**
-   * Return a settings object as the given class, attempting to create a new settings object of that
-   * class if the currently given settings are not of this class.
-   *
-   * @param clazz the setting clazz to create
-   * @param defaultValue if non=null this will be returned if the settings are absensce. If null
-   *     then will try to create a new instances of the Settings class
-   * @return may be null (if defaultValue is null)
-   */
-  default <T extends Settings> T getSettings(final Class<T> clazz, T defaultValue) {
-
-    return getSettings(clazz)
-        .orElseGet(
-            () -> {
-              if (defaultValue != null) {
-                return defaultValue;
-              } else {
-                try {
-                  return clazz.getConstructor().newInstance();
-                } catch (final Exception e) {
-                  return null;
-                }
-              }
-            });
-  }
-
   /**
    * Find the resource of the given type associated with the given key
    *

--- a/annot8-core/src/test/java/io/annot8/core/context/ContextTest.java
+++ b/annot8-core/src/test/java/io/annot8/core/context/ContextTest.java
@@ -24,40 +24,40 @@ import io.annot8.core.settings.Settings;
 
 public class ContextTest {
 
-  @Test
-  public void testGetSettings() {
-    Context context = Mockito.mock(Context.class);
-    Context context2 = Mockito.mock(Context.class);
-    TestSettings settings = new TestSettings();
-    Settings settings2 = Mockito.mock(Settings.class);
-    doReturn(Stream.of(settings)).when(context).getSettings();
-    doReturn(Stream.of(settings2)).when(context2).getSettings();
-    doCallRealMethod().when(context).getSettings(Mockito.any());
-    doCallRealMethod().when(context2).getSettings(Mockito.any());
-
-    assertEquals(settings, context.getSettings(TestSettings.class).get());
-    assertFalse(context2.getSettings(TestSettings.class).isPresent());
-  }
-
-  @Test
-  public void testGetSettingsWithDefault() {
-    Context context = Mockito.mock(Context.class);
-    TestSettings settings = new TestSettings();
-    doReturn(Optional.of(settings)).when(context).getSettings(TestSettings.class);
-    doReturn(Optional.empty()).when(context).getSettings(UnusedSettings.class);
-
-    doCallRealMethod().when(context).getSettings(Mockito.any(), Mockito.any());
-
-    // if it exists we get it (null or otherwise)
-    assertEquals(settings, context.getSettings(TestSettings.class, null));
-    assertEquals(settings, context.getSettings(TestSettings.class, new TestSettings()));
-
-    // If we don't have it, then if null we get a new instance
-    assertNotNull(context.getSettings(UnusedSettings.class, null));
-    // Or the default
-    UnusedSettings unusedSettings = new UnusedSettings();
-    assertEquals(unusedSettings, context.getSettings(UnusedSettings.class, unusedSettings));
-  }
+//  @Test
+//  public void testGetSettings() {
+//    Context context = Mockito.mock(Context.class);
+//    Context context2 = Mockito.mock(Context.class);
+//    TestSettings settings = new TestSettings();
+//    Settings settings2 = Mockito.mock(Settings.class);
+//    doReturn(Stream.of(settings)).when(context).getSettings();
+//    doReturn(Stream.of(settings2)).when(context2).getSettings();
+//    doCallRealMethod().when(context).getSettings(Mockito.any());
+//    doCallRealMethod().when(context2).getSettings(Mockito.any());
+//
+//    assertEquals(settings, context.getSettings(TestSettings.class).get());
+//    assertFalse(context2.getSettings(TestSettings.class).isPresent());
+//  }
+//
+//  @Test
+//  public void testGetSettingsWithDefault() {
+//    Context context = Mockito.mock(Context.class);
+//    TestSettings settings = new TestSettings();
+//    doReturn(Optional.of(settings)).when(context).getSettings(TestSettings.class);
+//    doReturn(Optional.empty()).when(context).getSettings(UnusedSettings.class);
+//
+//    doCallRealMethod().when(context).getSettings(Mockito.any(), Mockito.any());
+//
+//    // if it exists we get it (null or otherwise)
+//    assertEquals(settings, context.getSettings(TestSettings.class, null));
+//    assertEquals(settings, context.getSettings(TestSettings.class, new TestSettings()));
+//
+//    // If we don't have it, then if null we get a new instance
+//    assertNotNull(context.getSettings(UnusedSettings.class, null));
+//    // Or the default
+//    UnusedSettings unusedSettings = new UnusedSettings();
+//    assertEquals(unusedSettings, context.getSettings(UnusedSettings.class, unusedSettings));
+//  }
 
   @Test
   public void testGetResourceKeys() {
@@ -130,21 +130,21 @@ public class ContextTest {
     assertFalse(resource2.isPresent());
   }
 
-  public static class TestSettings implements Settings {
-
-    @Override
-    public boolean validate() {
-      return true;
-    }
-  }
-
-  public static class UnusedSettings implements Settings {
-
-    @Override
-    public boolean validate() {
-      return true;
-    }
-  }
+//  public static class TestSettings implements Settings {
+//
+//    @Override
+//    public boolean validate() {
+//      return true;
+//    }
+//  }
+//
+//  public static class UnusedSettings implements Settings {
+//
+//    @Override
+//    public boolean validate() {
+//      return true;
+//    }
+//  }
 
   public abstract class TestResource1 implements Resource {}
 

--- a/annot8-testing/annot8-test-impl/src/main/java/io/annot8/testing/testimpl/TestContext.java
+++ b/annot8-testing/annot8-test-impl/src/main/java/io/annot8/testing/testimpl/TestContext.java
@@ -12,29 +12,14 @@ import io.annot8.core.settings.Settings;
 
 public class TestContext implements Context {
 
-  private final Settings settings;
   private final Map<String, Resource> resources;
 
   public TestContext() {
-    this(null, Collections.emptyMap());
-  }
-
-  public TestContext(Settings settings) {
-    this(settings, Collections.emptyMap());
+    this(null);
   }
 
   public TestContext(Map<String, Resource> resources) {
-    this(null, resources);
-  }
-
-  public TestContext(Settings settings, Map<String, Resource> resources) {
-    this.settings = settings;
     this.resources = resources == null ? Collections.emptyMap() : resources;
-  }
-
-  @Override
-  public Stream<Settings> getSettings() {
-    return Stream.ofNullable(settings);
   }
 
   @Override

--- a/annot8-testing/annot8-test-impl/src/main/java/io/annot8/testing/testimpl/pipeline/TestPipelineComponentConfiguration.java
+++ b/annot8-testing/annot8-test-impl/src/main/java/io/annot8/testing/testimpl/pipeline/TestPipelineComponentConfiguration.java
@@ -14,15 +14,11 @@ public class TestPipelineComponentConfiguration implements ComponentConfiguratio
 
   private final String component;
 
-  private final Set<Settings> settings;
+  private final Settings settings;
 
-  public TestPipelineComponentConfiguration(String component, Set<Settings> settings) {
+  public TestPipelineComponentConfiguration(String component, Settings settings) {
     this.component = component;
     this.settings = settings;
-  }
-
-  public TestPipelineComponentConfiguration(String component, Settings... settings) {
-    this(component, new HashSet<>(Arrays.asList(settings)));
   }
 
   @Override
@@ -36,7 +32,7 @@ public class TestPipelineComponentConfiguration implements ComponentConfiguratio
   }
 
   @Override
-  public Set<Settings> getSettings() {
+  public Settings getSettings() {
     return settings;
   }
 }


### PR DESCRIPTION
Fixes #19  

Patches pipelines to allow building but settings as a constructor argument will effect (break) all the processors and resources.
